### PR TITLE
Use consistent 'qubit' term

### DIFF
--- a/QCore.md
+++ b/QCore.md
@@ -50,18 +50,18 @@ The measurement gate counts the number of photons in each mode for each qubit, t
 
 ##### Pauli-X Gate
 
-The Pauli-X Gate performs a NOT operation or bit flip on a single qbit.
+The Pauli-X Gate performs a NOT operation or bit flip on a single qubit.
 X|0> = |1>
 
 ##### Pauli-Y Gate
 
-The Pauli-Y Gate rotates one qbit around the y axis, it looks similar to an X gate, but with a global phase diffrence of i or -i. 
+The Pauli-Y Gate rotates one qubit around the y axis, it looks similar to an X gate, but with a global phase diffrence of i or -i.
 Y|0> = i|1> and Y|1> = -i|0>
 Note: This Pauli gate does not invert itself.
 
 ##### Pauli-Z Gate
 
-The Pauli-X Gate performs a NOT operation or bit flip on a single qbit, this time in the +/- basis. 
+The Pauli-X Gate performs a NOT operation or bit flip on a single qubit, this time in the +/- basis.
 Z|-> = |+>
 
 ##### Hadamard Gate

--- a/QCore.md
+++ b/QCore.md
@@ -72,7 +72,7 @@ H|1> = |+> , H|-> = |0>
 #### Controlled Gates
 
 Controlled gates utilize nonlinear sign-flip gates to introduce non-linearity into our programs. These non-linearities are extremely difficult to simulate as they actually entangle our qubit states, whereas the Unitary qubit transformations are easy to simulate comparatively. Effectively this is what gives our quantum computer an edge over typically digital computing.
-They act on two Qbits, the Control and Target. If the Control is 1, the operation is carried out otherwise it isn't.
+They act on two qubits, the Control and Target. If the Control is 1, the operation is carried out otherwise it isn't.
 
 ##### CX Gate
 


### PR DESCRIPTION
Minor and pedantic PR for consistent terminology. I sometime mix qbit / qubit too -- raising it before I forget, and existing documentation has been consistent with "qubit". 