### PR TITLE
Clickable links for exploring content from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,35 +44,35 @@ The QController acts as a bridge between the main (digital) computer and the qua
 
 | Type                | Directory   | Filename         | Description                |
 | ------------------- | ----------- | ---------------- | -------------------------- |
-| Project File        | 8Q/         | 8Q.pro           | Main KiCAD Project File    |
-| PCB Design File     | 8Q/         | 8Q.kicad_PCB     | Main KiCAD PCB File        |
-| Board Schematic     | 8Q/         | cpu.sch          | Main CPU Schematic         |
-| Board Schematic     | 8Q/         | cpu_power.sch    | CPU Power Schematic        |
-| Board Schematic     | 8Q/         | RAM.sch          | CPU RAM Schemati           |
-| QCore Schematic     | 8Q/         | qpu.sch          | Main QPU Schematic         |
-| QCore Schematic     | 8Q/         | qpower.sch       | QPU Power Schematic        |
-| QCore Schematic     | 8Q/         | preprocessor.sch | QPU Control Unit Schematic |
+| Project File        | [8Q/](./8Q) | 8Q.pro           | Main KiCAD Project File    |
+| PCB Design File     | [8Q/](./8Q) | 8Q.kicad_PCB     | Main KiCAD PCB File        |
+| Board Schematic     | [8Q/](./8Q) | cpu.sch          | Main CPU Schematic         |
+| Board Schematic     | [8Q/](./8Q) | cpu_power.sch    | CPU Power Schematic        |
+| Board Schematic     | [8Q/](./8Q) | RAM.sch          | CPU RAM Schematic          |
+| QCore Schematic     | [8Q/](./8Q) | qpu.sch          | Main QPU Schematic         |
+| QCore Schematic     | [8Q/](./8Q) | qpower.sch       | QPU Power Schematic        |
+| QCore Schematic     | [8Q/](./8Q) | preprocessor.sch | QPU Control Unit Schematic |
 | Manufacturing Files | 8Q/gerber   | none             | none (gerber files)        |
 | Manufacturing Files | 8Q/assembly | none             | none (assembly files)      |
 
 #### Documentation Files
 
-| Type              | Directory         | Filename         | Description                                |
-| ----------------- | ----------------- | ---------------- | ------------------------------------------ |
-| Makefile          | docs/             | Makefile         | Used to build documentation                |
-| Folder            | docs/build/       | *                | Build files for docs                       |
-| Folder            | docs/source/      | *                | Documentation source files                 |
-| Folder            | docs/source/imgs/ | *                | Image files                                |
-| ReStructured Text | docs/source/      | architecture.rst | Instruction Set Architecture Documentation |
-| ReStructured Text | docs/source/      | board.rst        | Board Hardware Information                 |
-| Python            | docs/source/      | conf.py          | Docs Generator Configs                     |
-| ReStructured Text | docs/source/      | index.rst        | Documentation Home Page                    |
-| ReStructured Text | docs/source       | programming.rst  | Programming Documentation                  |
+| Type              | Directory                     | Filename         | Description                                |
+| ----------------- | ----------------------------- | ---------------- | ------------------------------------------ |
+| Makefile          | [docs/](./docs)               | Makefile         | Used to build documentation                |
+| Folder            | [docs/build/](./docs/build)   | *                | Build files for docs                       |
+| Folder            | [docs/source/](./docs/source) | *                | Documentation source files                 |
+| Folder            | [docs/source/imgs/](./docs/source/imgs) | *      | Image files                                |
+| ReStructured Text | [docs/source/](./docs/source) | architecture.rst | Instruction Set Architecture Documentation |
+| ReStructured Text | [docs/source/](./docs/source) | board.rst        | Board Hardware Information                 |
+| Python            | [docs/source/](./docs/source) | conf.py          | Docs Generator Configs                     |
+| ReStructured Text | [docs/source/](./docs/source) | index.rst        | Documentation Home Page                    |
+| ReStructured Text | [docs/source/](./docs/source) | programming.rst  | Programming Documentation                  |
 
 #### Firmware/Software Sources
 
-None: src/
+None: [src/](./src)
 
 #### Development Tools
 
-None: tools/
+None: [tools/](./tools)


### PR DESCRIPTION
Was hoping to do more with this, but I think it's done for now. I was trying to locate the schematics for the missing images mentioned in #14 and explore the kicad files. Unfortunately I couldn't find any of the detailed schematics with mirrors, or the faint laser schematic from [QCore.md](https://github.com/Spooky-Manufacturing/8Q/blob/master/QCore.md), it looks like the sources for 

* [cx_gate.png](https://github.com/Spooky-Manufacturing/8Q/blob/master/docs/source/imgs/cx_gate.png)
* [faint_laser.png](https://github.com/Spooky-Manufacturing/8Q/blob/master/docs/source/imgs/faint_laser.png)
* [ns_1_gate.png](https://github.com/Spooky-Manufacturing/8Q/blob/master/docs/source/imgs/ns_1_gate.png)

from https://github.com/Spooky-Manufacturing/8Q/tree/master/docs/source/imgs are gone. The files in [/8Q/QGates.pretty](https://github.com/Spooky-Manufacturing/8Q/tree/master/8Q/QGates.pretty) are high level single component symbols which do not show how they are constructed. They are viewable in kicad and could be converted to png, but those won't help in  [QCore.md](https://github.com/Spooky-Manufacturing/8Q/blob/master/QCore.md).


I also had a look in https://github.com/Spooky-Manufacturing/QEDA ,  https://github.com/Spooky-Manufacturing/QEDA_old , and https://github.com/Spooky-Manufacturing/UniversalGateSet just in case. No luck.

Documenting my failure here so others know that someone else has looked too. :)

I should probably introduce myself in Discussion. I was quite interested in the faint laser schematic, and in building and testing the operation of anything close to a single optical qubit (or DIY optical computing in general), which is how I found this project. I spent some time playing with the [old QEDA](https://github.com/Spooky-Manufacturing/QEDA_old) version a while back.